### PR TITLE
Improve mod integrations

### DIFF
--- a/src/main/java/com/fullskele/lootbeamsretro/LootBeamsRetro.java
+++ b/src/main/java/com/fullskele/lootbeamsretro/LootBeamsRetro.java
@@ -1,11 +1,9 @@
 package com.fullskele.lootbeamsretro;
 
 import com.fullskele.lootbeamsretro.config.Config;
-import com.fullskele.lootbeamsretro.render.RenderEventHandler;
 import net.minecraftforge.fml.common.Loader;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 @Mod(
@@ -33,10 +31,5 @@ public class LootBeamsRetro
     @Mod.EventHandler
     public void init(FMLInitializationEvent event) {
         Config.loadItems(false);
-    }
-
-    @Mod.EventHandler
-    public void postInit(FMLPostInitializationEvent event) {
-        RenderEventHandler.integrateLegendaryTooltips();
     }
 }

--- a/src/main/java/com/fullskele/lootbeamsretro/config/Config.java
+++ b/src/main/java/com/fullskele/lootbeamsretro/config/Config.java
@@ -14,8 +14,8 @@ import net.minecraftforge.common.config.Configuration;
 import org.apache.commons.lang3.tuple.Pair;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 public final class Config {
 
@@ -294,7 +294,6 @@ public final class Config {
         if (reload) {
             load();
             RenderEventHandler.COLOR_OVERRIDES.clear();
-            RenderEventHandler.integrateLegendaryTooltips();
         }
 
         for (String entry : colorOverrides) {
@@ -320,10 +319,10 @@ public final class Config {
         }
     }
 
-    public static Stream<ItemStack> getSubItems(Item item) {
+    public static Iterable<ItemStack> getSubItems(Item item) {
         NonNullList<ItemStack> items = NonNullList.create();
         item.getSubItems(CreativeTabs.SEARCH, items);
-        return !items.isEmpty() ? items.stream() : Stream.of(new ItemStack(item));
+        return !items.isEmpty() ? items : Collections.singleton(new ItemStack(item));
     }
 
     public static float[] hexToRgb(int hex) {

--- a/src/main/java/com/fullskele/lootbeamsretro/config/ConfigEventHandler.java
+++ b/src/main/java/com/fullskele/lootbeamsretro/config/ConfigEventHandler.java
@@ -1,6 +1,7 @@
 package com.fullskele.lootbeamsretro.config;
 
 import com.fullskele.lootbeamsretro.LootBeamsRetro;
+import com.fullskele.lootbeamsretro.render.RenderEventHandler;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
@@ -19,7 +20,7 @@ public class ConfigEventHandler
         }
 
         else if (event.getModID().equals("legendarytooltips") && Config.legendaryTooltipsCompat) {
-            Config.loadItems(true);
+            RenderEventHandler.LEGENDARY_TOOLTIPS_COLOR_OVERRIDES = null;
         }
     }
 }


### PR DESCRIPTION
- Fix https://github.com/fullskele/LootBeamsRetro-Mod-1.12.2/issues/3.
- Only load Legendary Tooltips colors as-needed.
- Prioritize beam colors specified by this mod's config.